### PR TITLE
fix encryption driver name mismatch

### DIFF
--- a/content/guides/security/encryption.md
+++ b/content/guides/security/encryption.md
@@ -285,7 +285,7 @@ export default defineConfig({
   default: 'chacha',
 
   list: {
-    chacha: drivers.chacha20poly1305({
+    chacha: drivers.chacha20({
       id: 'chacha',
       keys: [env.get('APP_KEY')],
     }),
@@ -343,7 +343,7 @@ export default defineConfig({
   default: 'chacha',
 
   list: {
-    chacha: drivers.chacha20poly1305({
+    chacha: drivers.chacha20({
       id: 'chacha',
       // [!code highlight:4]
       keys: [


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

adonisjs/core#5056

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The documentation references `drivers.chacha20poly1305`, 
but the actual exported driver is `drivers.chacha20` 
as seen in [adonisjs/core](https://github.com/adonisjs/core/blob/602a3f4ab9e3cea5c479f2036a2dc87800eac4a2/modules/encryption/define_config.ts#L156)

Resolves adonisjs/core#5056

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
