### PR TITLE
docs(frontend): fix export registry

### DIFF
--- a/content/guides/frontend/api_client.md
+++ b/content/guides/frontend/api_client.md
@@ -192,7 +192,7 @@ Configure your backend `package.json` to export the generated Tuyau files so you
   "private": true,
   "type": "module",
   "exports": { // [!code highlight]
-    "./registry": "./.adonisjs/client/registry.ts", // [!code highlight]
+    "./registry": "./.adonisjs/client/registry/index.ts", // [!code highlight]
     "./data": "./.adonisjs/client/data.d.ts" // [!code highlight]
   } // [!code highlight]
 }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Not an issue but i mentioned it in discord

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
I followed the documentation to migrate my AdonisJS v6 project to v7, and while following the Tuyau setup guide, I noticed that the export path for the registry was incorrect.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
