### PR TITLE
docs(auth): fix broken links in auth guides

### DIFF
--- a/content/guides/auth/access_tokens_guard.md
+++ b/content/guides/auth/access_tokens_guard.md
@@ -117,7 +117,7 @@ export default class extends BaseSchema {
 
 ## Issuing tokens
 
-Use the tokens provider on your User model to create tokens. The `create` method accepts a user instance and returns an [AccessToken](https://github.com/adonisjs/auth/blob/main/modules/access_tokens_guard/access_token.ts) object:
+Use the tokens provider on your User model to create tokens. The `create` method accepts a user instance and returns an [AccessToken](https://github.com/adonisjs/auth/blob/10.x/modules/access_tokens_guard/access_token.ts) object:
 ```ts title="start/routes.ts"
 import User from '#models/user'
 import router from '@adonisjs/core/services/router'
@@ -233,7 +233,7 @@ const authConfig = defineConfig({
 export default authConfig
 ```
 
-The `tokensGuard` method creates an instance of [AccessTokensGuard](https://github.com/adonisjs/auth/blob/main/modules/access_tokens_guard/guard.ts).
+The `tokensGuard` method creates an instance of [AccessTokensGuard](https://github.com/adonisjs/auth/blob/10.x/modules/access_tokens_guard/guard.ts).
 
 The `tokensUserProvider` method accepts two options:
 

--- a/content/guides/auth/introduction.md
+++ b/content/guides/auth/introduction.md
@@ -32,7 +32,7 @@ The auth package focuses specifically on authenticating HTTP requests. The follo
 
 :::tip
 
-Looking for a complete authentication system? [AdonisJS Kit](https://adonisjs.com/kit) provides full-stack components with ready-to-use flows for user registration, email verification, password recovery, profile management, and more.
+Looking for a complete authentication system? [AdonisJS Kit](https://plus.adonisjs.com/kit) provides full-stack components with ready-to-use flows for user registration, email verification, password recovery, profile management, and more.
 
 :::
 
@@ -138,7 +138,7 @@ node ace add @adonisjs/auth --guard=basic_auth
 
 ## The initialize auth middleware
 
-During setup, the `@adonisjs/auth/initialize_auth_middleware` is added to your application's middleware stack. This middleware runs on every request and creates an instance of the [Authenticator](https://github.com/adonisjs/auth/blob/main/src/authenticator.ts) class, which it attaches to `ctx.auth`.
+During setup, the `@adonisjs/auth/initialize_auth_middleware` is added to your application's middleware stack. This middleware runs on every request and creates an instance of the [Authenticator](https://github.com/adonisjs/auth/blob/10.x/src/authenticator.ts) class, which it attaches to `ctx.auth`.
 
 The initialize auth middleware does not authenticate requests or protect routes. Its only job is to set up the authenticator instance so it's available throughout the request lifecycle. To protect routes, use the [auth middleware](./session_guard.md#protecting-routes).
 

--- a/content/guides/auth/session_guard.md
+++ b/content/guides/auth/session_guard.md
@@ -41,9 +41,9 @@ const authConfig = defineConfig({
 export default authConfig
 ```
 
-The `sessionGuard` method creates an instance of the [SessionGuard](https://github.com/adonisjs/auth/blob/main/modules/session_guard/guard.ts) class. It accepts a user provider and an optional configuration object for remember me tokens.
+The `sessionGuard` method creates an instance of the [SessionGuard](https://github.com/adonisjs/auth/blob/10.x/modules/session_guard/guard.ts) class. It accepts a user provider and an optional configuration object for remember me tokens.
 
-The `sessionUserProvider` method creates an instance of [SessionLucidUserProvider](https://github.com/adonisjs/auth/blob/main/modules/session_guard/user_providers/lucid.ts), which uses a Lucid model to find users during authentication.
+The `sessionUserProvider` method creates an instance of [SessionLucidUserProvider](https://github.com/adonisjs/auth/blob/10.x/modules/session_guard/user_providers/lucid.ts), which uses a Lucid model to find users during authentication.
 
 ## Logging in
 
@@ -136,7 +136,7 @@ When multiple guards are specified, authentication succeeds if any of them authe
 
 ### Handling authentication errors
 
-When the auth middleware cannot authenticate a request, it throws the [E_UNAUTHORIZED_ACCESS](https://github.com/adonisjs/auth/blob/main/src/errors.ts#L21) exception. The exception is converted to an HTTP response using content negotiation:
+When the auth middleware cannot authenticate a request, it throws the [E_UNAUTHORIZED_ACCESS](https://github.com/adonisjs/auth/blob/10.x/src/errors.ts#L21) exception. The exception is converted to an HTTP response using content negotiation:
 
 - Requests with `Accept: application/json` receive an array of error objects.
 - Requests with `Accept: application/vnd.api+json` receive errors formatted per the JSON API specification.

--- a/content/guides/auth/verifying_user_credentials.md
+++ b/content/guides/auth/verifying_user_credentials.md
@@ -153,7 +153,7 @@ export default class HttpExceptionHandler extends ExceptionHandler {
 
 ## Automatic password hashing
 
-The AuthFinder mixin registers a [beforeSave hook](https://github.com/adonisjs/auth/blob/main/src/mixins/lucid.ts#L40-L50) that automatically hashes passwords when creating or updating users. You don't need to manually hash passwords in your models or controllers:
+The AuthFinder mixin registers a [beforeSave hook](https://github.com/adonisjs/auth/blob/10.x/src/mixins/lucid.ts#L88-L95) that automatically hashes passwords when creating or updating users. You don't need to manually hash passwords in your models or controllers:
 ```ts title="app/controllers/users_controller.ts"
 import User from '#models/user'
 import type { HttpContext } from '@adonisjs/core/http'


### PR DESCRIPTION
## Summary

Fixes 8 broken links across the authentication guides. All `blob/main/...` GitHub references pointed to a branch that does not exist on the `adonisjs/auth` repo (its default branch is `10.x`), and one link used an outdated host for AdonisJS Kit.

## Changes

### `content/guides/auth/introduction.md`
| Old URL | New URL |
|---|---|
| `https://adonisjs.com/kit` | `https://plus.adonisjs.com/kit` |
| `github.com/adonisjs/auth/blob/main/src/authenticator.ts` | `.../blob/10.x/src/authenticator.ts` |

### `content/guides/auth/session_guard.md`
| Old URL | New URL |
|---|---|
| `.../blob/main/modules/session_guard/guard.ts` | `.../blob/10.x/modules/session_guard/guard.ts` |
| `.../blob/main/modules/session_guard/user_providers/lucid.ts` | `.../blob/10.x/modules/session_guard/user_providers/lucid.ts` |
| `.../blob/main/src/errors.ts#L21` | `.../blob/10.x/src/errors.ts#L21` |

### `content/guides/auth/access_tokens_guard.md`
| Old URL | New URL |
|---|---|
| `.../blob/main/modules/access_tokens_guard/access_token.ts` | `.../blob/10.x/modules/access_tokens_guard/access_token.ts` |
| `.../blob/main/modules/access_tokens_guard/guard.ts` | `.../blob/10.x/modules/access_tokens_guard/guard.ts` |

### `content/guides/auth/verifying_user_credentials.md`
| Old URL | New URL |
|---|---|
| `.../blob/main/src/mixins/lucid.ts#L40-L50` | `.../blob/10.x/src/mixins/lucid.ts#L88-L95` |

The mixin anchor was also updated to point to the current `beforeSave` hook location on `10.x`.

## Verification

Every target URL was verified with `curl -L`:
- HTTP status `200` on all 8 new links
- Line anchors (`#L21`, `#L88-L95`) resolve to the expected code on the `10.x` branch