### PR TITLE
docs(concepts,reference): fix broken links to package sources

### DIFF
--- a/content/guides/concepts/extending_adonisjs.md
+++ b/content/guides/concepts/extending_adonisjs.md
@@ -476,7 +476,7 @@ app.getter('isProduction', function () {
 })
 ```
 
-[View source](https://github.com/adonisjs/application/blob/main/src/application.ts)
+[View source](https://github.com/adonisjs/application/blob/9.x/src/application.ts)
 :::
 
 :::option{name="HttpRequest" import="@adonisjs/core/http"}
@@ -494,7 +494,7 @@ HttpRequest.macro('isAjax', function (this: HttpRequest) {
 })
 ```
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/request.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/request.ts)
 :::
 
 :::option{name="HttpResponse" import="@adonisjs/core/http"}
@@ -512,7 +512,7 @@ HttpResponse.macro('paginated', function (this: HttpResponse, data: any, meta: a
 })
 ```
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/response.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/response.ts)
 :::
 
 :::option{name="HttpContext" import="@adonisjs/core/http"}
@@ -530,7 +530,7 @@ HttpContext.macro('getCurrentUser', async function (this: HttpContext) {
 })
 ```
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/http_context/main.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/http_context/main.ts)
 :::
 
 :::option{name="Route" import="@adonisjs/core/http"}
@@ -548,7 +548,7 @@ Route.macro('protected', function (this: Route) {
 })
 ```
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/router/route.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/router/route.ts)
 :::
 
 :::option{name="RouteGroup" import="@adonisjs/core/http"}
@@ -566,7 +566,7 @@ RouteGroup.macro('apiVersion', function (this: RouteGroup, version: number) {
 })
 ```
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/router/group.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/router/group.ts)
 :::
 
 :::option{name="RouteResource" import="@adonisjs/core/http"}
@@ -574,7 +574,7 @@ Resourceful route instances. Extend this to customize resource route behavior.
 
 **Common use cases**: Add methods for customizing which resource routes are created or adding resource-specific middleware.
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/router/resource.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/router/resource.ts)
 :::
 
 :::option{name="BriskRoute" import="@adonisjs/core/http"}
@@ -582,7 +582,7 @@ Brisk (quick) route instances used for simple route definitions. Extend this for
 
 **Common use cases**: Add convenience methods for quick route configurations.
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/router/brisk.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/router/brisk.ts)
 :::
 
 :::option{name="ExceptionHandler" import="@adonisjs/core/http"}
@@ -600,7 +600,7 @@ ExceptionHandler.macro('handleValidationError', function (error: any) {
 })
 ```
 
-[View source](https://github.com/adonisjs/http-server/blob/main/src/exception_handler.ts)
+[View source](https://github.com/adonisjs/http-server/blob/8.x/src/exception_handler.ts)
 :::
 
 :::option{name="MultipartFile" import="@adonisjs/core/bodyparser"}
@@ -618,7 +618,7 @@ MultipartFile.macro('isImage', function (this: MultipartFile) {
 })
 ```
 
-[View source](https://github.com/adonisjs/bodyparser/blob/main/src/multipart/file.ts)
+[View source](https://github.com/adonisjs/bodyparser/blob/11.x/src/multipart/file.ts)
 :::
 
 ::::

--- a/content/reference/application.md
+++ b/content/reference/application.md
@@ -14,7 +14,7 @@ This guide covers the Application class in AdonisJS. You will learn how to:
 
 ## Overview
 
-The [Application](https://github.com/adonisjs/application/blob/main/src/application.ts) class handles the heavy lifting of wiring together an AdonisJS application. It manages the application lifecycle, provides access to environment information, tracks the current state, and offers helper methods for generating paths to various project directories.
+The [Application](https://github.com/adonisjs/application/blob/9.x/src/application.ts) class handles the heavy lifting of wiring together an AdonisJS application. It manages the application lifecycle, provides access to environment information, tracks the current state, and offers helper methods for generating paths to various project directories.
 
 You access the Application instance through the `app` service, which is available throughout your application.
 
@@ -486,4 +486,4 @@ app.generators.controllerName('user')
 // UsersController
 ```
 
-See the [`generators.ts` source code](https://github.com/adonisjs/application/blob/main/src/generators.ts) for the complete list of available generators.
+See the [`generators.ts` source code](https://github.com/adonisjs/application/blob/9.x/src/generators.ts) for the complete list of available generators.

--- a/content/reference/edge.md
+++ b/content/reference/edge.md
@@ -127,7 +127,7 @@ Reference to an instance of the I18n class configured using the application's de
 ```
 
 ## auth
-Reference to the [ctx.auth](../guides/basics/http_context.md#http-context-properties) property shared by the [InitializeAuthMiddleware](https://github.com/adonisjs/auth/blob/main/src/auth/middleware/initialize_auth_middleware.ts#L14). You may use this property to access information about the logged-in user.
+Reference to the [ctx.auth](../guides/basics/http_context.md#http-context-properties) property shared by the [InitializeAuthMiddleware](https://github.com/adonisjs/auth/blob/10.x/src/middleware/initialize_auth_middleware.ts#L19-L48). You may use this property to access information about the logged-in user.
 
 ```edge
 @if(auth.isAuthenticated)

--- a/content/reference/events.md
+++ b/content/reference/events.md
@@ -8,7 +8,7 @@ In this guide, we look at the list of events dispatched by the framework core an
 
 ## http\:request_completed
 
-The [`http:request_completed`](https://github.com/adonisjs/http-server/blob/main/src/types/server.ts#L65) event is dispatched after an HTTP request is completed. The event contains an instance of the [HttpContext](../guides/basics/http_context.md) and the request duration. The `duration` value is the output of the `process.hrtime` method.
+The [`http:request_completed`](https://github.com/adonisjs/http-server/blob/8.x/src/types/server.ts#L65-L81) event is dispatched after an HTTP request is completed. The event contains an instance of the [HttpContext](../guides/basics/http_context.md) and the request duration. The `duration` value is the output of the `process.hrtime` method.
 
 ```ts
 import emitter from '@adonisjs/core/services/emitter'
@@ -55,7 +55,7 @@ emitter.on('container_binding:resolved', (event) => {
 ```
 
 ## session\:initiated
-The `@adonisjs/session` package emits the event when the session store is initiated during an HTTP request. The `event.session` property is an instance of the [Session class](https://github.com/adonisjs/session/blob/main/src/session.ts).
+The `@adonisjs/session` package emits the event when the session store is initiated during an HTTP request. The `event.session` property is an instance of the [Session class](https://github.com/adonisjs/session/blob/8.x/src/session.ts).
 
 ```ts
 import emitter from '@adonisjs/core/services/emitter'
@@ -156,7 +156,7 @@ emitter.on('mail:queued', (event) => {
 ```
 
 ## queued\:mail\:error
-The event is dispatched when the [MemoryQueue](https://github.com/adonisjs/mail/blob/main/src/messengers/memory_queue.ts) implementation of the `@adonisjs/mail` package is unable to send the email queued using the `mail.sendLater` method.
+The event is dispatched when the [MemoryQueue](https://github.com/adonisjs/mail/blob/10.x/src/messengers/memory_queue.ts) implementation of the `@adonisjs/mail` package is unable to send the email queued using the `mail.sendLater` method.
 
 If you are using a custom queue implementation, you must capture the job errors and emit this event.
 
@@ -171,7 +171,7 @@ emitter.on('queued:mail:error', (event) => {
 
 ## session_auth\:login_attempted
 
-The event is dispatched by the [SessionGuard](https://github.com/adonisjs/auth/blob/main/src/guards/session/guard.ts) implementation of the `@adonisjs/auth` package when the `auth.login` method is called either directly or internally by the session guard.
+The event is dispatched by the [SessionGuard](https://github.com/adonisjs/auth/blob/10.x/modules/session_guard/guard.ts) implementation of the `@adonisjs/auth` package when the `auth.login` method is called either directly or internally by the session guard.
 
 ```ts
 import emitter from '@adonisjs/core/services/emitter'
@@ -184,7 +184,7 @@ emitter.on('session_auth:login_attempted', (event) => {
 
 ## session_auth\:login_succeeded
 
-The event is dispatched by the [SessionGuard](https://github.com/adonisjs/auth/blob/main/src/guards/session/guard.ts) implementation of the `@adonisjs/auth` package after a user has been logged in successfully. 
+The event is dispatched by the [SessionGuard](https://github.com/adonisjs/auth/blob/10.x/modules/session_guard/guard.ts) implementation of the `@adonisjs/auth` package after a user has been logged in successfully. 
 
 You may use this event to track sessions associated with a given user.
 

--- a/content/reference/exceptions.md
+++ b/content/reference/exceptions.md
@@ -77,7 +77,7 @@ if (error instanceof shieldErrors.E_BAD_CSRF_TOKEN) {
 }
 ```
 
-The `E_BAD_CSRF_TOKEN` exception is [self-handled](https://github.com/adonisjs/shield/blob/main/src/errors.ts#L20), and the user will be redirected back to the form, and you can access the error using the flash messages.
+The `E_BAD_CSRF_TOKEN` exception is [self-handled](https://github.com/adonisjs/shield/blob/9.x/src/errors.ts#L23-L66), and the user will be redirected back to the form, and you can access the error using the flash messages.
 
 ```edge
 @error('E_BAD_CSRF_TOKEN')


### PR DESCRIPTION
## Summary

Fixes 18 broken GitHub source links across the Concepts and Reference guides. Most packages in the AdonisJS ecosystem do not use `main` as their default branch, so every `blob/main/...` URL pointing to a package source file returned a 404. Each link was retargeted to the correct default branch for its package.

## Changes

### `content/guides/concepts/extending_adonisjs.md` (10 links)
| Package | From | To |
|---|---|---|
| `application` | `blob/main/src/application.ts` | `blob/9.x/src/application.ts` |
| `http-server` | `blob/main/src/request.ts` | `blob/8.x/src/request.ts` |
| `http-server` | `blob/main/src/response.ts` | `blob/8.x/src/response.ts` |
| `http-server` | `blob/main/src/http_context/main.ts` | `blob/8.x/src/http_context/main.ts` |
| `http-server` | `blob/main/src/router/route.ts` | `blob/8.x/src/router/route.ts` |
| `http-server` | `blob/main/src/router/group.ts` | `blob/8.x/src/router/group.ts` |
| `http-server` | `blob/main/src/router/resource.ts` | `blob/8.x/src/router/resource.ts` |
| `http-server` | `blob/main/src/router/brisk.ts` | `blob/8.x/src/router/brisk.ts` |
| `http-server` | `blob/main/src/exception_handler.ts` | `blob/8.x/src/exception_handler.ts` |
| `bodyparser` | `blob/main/src/multipart/file.ts` | `blob/11.x/src/multipart/file.ts` |

### `content/reference/application.md` (2 links)
| From | To |
|---|---|
| `application/blob/main/src/application.ts` | `application/blob/9.x/src/application.ts` |
| `application/blob/main/src/generators.ts` | `application/blob/9.x/src/generators.ts` |

### `content/reference/edge.md` (1 link, path also changed)
| From | To |
|---|---|
| `auth/blob/main/src/auth/middleware/initialize_auth_middleware.ts#L14` | `auth/blob/10.x/src/middleware/initialize_auth_middleware.ts#L19-L48` |

The middleware was moved from `src/auth/middleware/` to `src/middleware/` on the `10.x` branch, and the anchor was updated to point to the current `handle` method.

### `content/reference/events.md` (4 unique URLs, 5 references)
| From | To |
|---|---|
| `http-server/blob/main/src/types/server.ts#L65` | `http-server/blob/8.x/src/types/server.ts#L65-L81` |
| `session/blob/main/src/session.ts` | `session/blob/8.x/src/session.ts` |
| `mail/blob/main/src/messengers/memory_queue.ts` | `mail/blob/10.x/src/messengers/memory_queue.ts` |
| `auth/blob/main/src/guards/session/guard.ts` (×2) | `auth/blob/10.x/modules/session_guard/guard.ts` |

The session guard was moved from `src/guards/session/` to `modules/session_guard/` on the `10.x` branch.

### `content/reference/exceptions.md` (1 link)
| From | To |
|---|---|
| `shield/blob/main/src/errors.ts#L20` | `shield/blob/9.x/src/errors.ts#L23-L66` |

## Verification

Every new URL was verified with `curl -L`:
- All 18 updated links return HTTP 200
- The 2 paths that moved (`initialize_auth_middleware.ts` and `session_guard/guard.ts`) resolve on the correct branch
- Line anchors were updated to point to the current relevant code on each branch