### PR TITLE
docs(digging-deeper): fix broken external and package links

### DIFF
--- a/content/guides/digging_deeper/cache.md
+++ b/content/guides/digging_deeper/cache.md
@@ -56,7 +56,7 @@ node ace add @adonisjs/cache
 
 The cache configuration lives in `config/cache.ts`. This file defines your stores, the default store, and driver-specific settings.
 
-See also: [Config stub](https://github.com/adonisjs/cache/blob/-/stubs/config/cache.stub)
+See also: [Config stub](https://github.com/adonisjs/cache/blob/2.x/stubs/config.stub)
 
 ```ts title="config/cache.ts"
 import { defineConfig, store, drivers } from '@adonisjs/cache'

--- a/content/guides/digging_deeper/i18n.md
+++ b/content/guides/digging_deeper/i18n.md
@@ -80,7 +80,7 @@ const i18nConfig = defineConfig({
 export default i18nConfig
 ```
 
-See also: [Config stub](https://github.com/adonisjs/i18n/blob/main/stubs/config/i18n.stub)
+See also: [Config stub](https://github.com/adonisjs/i18n/blob/3.x/stubs/config/i18n.stub)
 
 ### Configuration options
 

--- a/content/guides/digging_deeper/mail.md
+++ b/content/guides/digging_deeper/mail.md
@@ -119,13 +119,13 @@ export default mailConfig
 
 Each transport accepts provider-specific options. The following sections document the available transports and their configuration.
 
-See also: [TypeScript types for config object](https://github.com/adonisjs/mail/blob/main/src/types.ts#L261)
+See also: [TypeScript types for config object](https://github.com/adonisjs/mail/blob/10.x/src/types.ts#L243)
 
 :::disclosure{title="SMTP"}
 
 SMTP configuration options are forwarded directly to Nodemailer.
 
-See also: [Nodemailer SMTP documentation](https://nodemailer.com/smtp/)
+See also: [Nodemailer SMTP documentation](https://nodemailer.com/smtp)
 
 ```ts title="config/mail.ts"
 {
@@ -183,7 +183,7 @@ Configuration options are sent to Resend's [`/emails`](https://resend.com/docs/a
 
 :::disclosure{title="Mailgun"}
 
-Configuration options are sent to Mailgun's [`/messages.mime`](https://documentation.mailgun.com/en/latest/api-sending.html#sending) API endpoint.
+Configuration options are sent to Mailgun's [`/messages.mime`](https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/messages/post-v3--domain-name--messages-mime) API endpoint.
 
 ```ts title="config/mail.ts"
 {
@@ -252,7 +252,7 @@ SES configuration options are forwarded to Nodemailer. You must install the AWS 
 npm i @aws-sdk/client-sesv2
 ```
 
-See also: [Nodemailer SES documentation](https://nodemailer.com/transports/ses/)
+See also: [Nodemailer SES documentation](https://nodemailer.com/transports/ses)
 
 ```ts title="config/mail.ts"
 {
@@ -751,7 +751,7 @@ await mail.send((message) => {
 })
 ```
 
-See also: [Nodemailer list headers documentation](https://nodemailer.com/message/list-headers/)
+See also: [Nodemailer list headers documentation](https://nodemailer.com/message/list-headers)
 
 ## Class-based emails
 


### PR DESCRIPTION
## Summary

Fixes 7 broken links across the Digging Deeper guides. The issues were a mix of package source links pointing to a non-existent `main` branch, a malformed cache stub URL, Nodemailer documentation URLs that now 404 due to trailing slashes, and an obsolete Mailgun API endpoint.

## Changes

### `content/guides/digging_deeper/mail.md` (5 links)
| From | To |
|---|---|
| `mail/blob/main/src/types.ts#L261` | `mail/blob/10.x/src/types.ts#L243` |
| `nodemailer.com/smtp/` | `nodemailer.com/smtp` |
| `nodemailer.com/transports/ses/` | `nodemailer.com/transports/ses` |
| `nodemailer.com/message/list-headers/` | `nodemailer.com/message/list-headers` |
| `documentation.mailgun.com/en/latest/api-sending.html#sending` | `documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/messages/post-v3--domain-name--messages-mime` |

- The types link points to the current default branch (`10.x`) with an anchor adjusted to the current config type location.
- Nodemailer moved to a new documentation site where trailing slashes 404. Removing them restores the pages.
- The Mailgun reference was migrated from the legacy ReadTheDocs URL to the current documentation portal.

### `content/guides/digging_deeper/cache.md` (1 link)
| From | To |
|---|---|
| `cache/blob/-/stubs/config/cache.stub` | `cache/blob/2.x/stubs/config.stub` |

The previous URL used a placeholder `-` as the ref and a nested `config/` directory that does not exist. Fixed to the current `2.x` branch and the actual stub location.

### `content/guides/digging_deeper/i18n.md` (1 link)
| From | To |
|---|---|
| `i18n/blob/main/stubs/config/i18n.stub` | `i18n/blob/3.x/stubs/config/i18n.stub` |

## Verification

All 7 new URLs were verified with `curl -L` and return HTTP 200.

A full scan of outbound links in the 3 modified files was also run. Every clickable markdown link resolves to HTTP 200. The remaining non-200 results are strings inside code blocks (example API endpoints like `https://api.mailgun.net/v3`, `https://api.resend.com`, or `https://example.com/...` placeholders), which are not clickable links.
