### PR TITLE
docs(database,frontend): fix broken links to package sources

### DIFF
--- a/content/guides/database/redis.md
+++ b/content/guides/database/redis.md
@@ -58,7 +58,7 @@ node ace add @adonisjs/redis
 
 The configuration for the Redis package is stored inside the `config/redis.ts` file.
 
-See also: [Config file stub](https://github.com/adonisjs/redis/blob/main/stubs/config/redis.stub)
+See also: [Config file stub](https://github.com/adonisjs/redis/blob/10.x/stubs/config/redis.stub)
 
 ```ts title="config/redis.ts"
 import env from '#start/env'

--- a/content/guides/frontend/api_client.md
+++ b/content/guides/frontend/api_client.md
@@ -29,7 +29,7 @@ Tuyau installation differs depending on whether you're using Inertia (single rep
 
 ### Inertia applications
 
-For Inertia applications, installation is straightforward since your frontend and backend live in the same repository. **Official starter kits for [React](https://github.com/adonisjs/react-starter-kit/inertia-react) and [Vue](https://github.com/adonisjs/react-starter-kit/inertia-vue) come pre-configured with Tuyau, hence no manual setup is required.**
+For Inertia applications, installation is straightforward since your frontend and backend live in the same repository. **Official starter kits for [React](https://github.com/adonisjs/starter-kits/tree/main/inertia-react) and [Vue](https://github.com/adonisjs/starter-kits/tree/main/inertia-vue) come pre-configured with Tuyau, hence no manual setup is required.**
 
 ::::steps
 


### PR DESCRIPTION
## Summary

Fixes 3 broken links across the Database and Frontend guides. The Redis config stub URL pointed to a non-existent `main` branch, and two starter kit links used an incorrect repository name (`react-starter-kit`) that doesn't exist; they actually live as directories inside the `starter-kits` monorepo.

## Changes

### `content/guides/database/redis.md` (1 link)
| From | To |
|---|---|
| `redis/blob/main/stubs/config/redis.stub` | `redis/blob/10.x/stubs/config/redis.stub` |

The `adonisjs/redis` repository uses `10.x` as its default branch.

### `content/guides/frontend/api_client.md` (2 links)
| From | To |
|---|---|
| `github.com/adonisjs/react-starter-kit/inertia-react` | `github.com/adonisjs/starter-kits/tree/main/inertia-react` |
| `github.com/adonisjs/react-starter-kit/inertia-vue` | `github.com/adonisjs/starter-kits/tree/main/inertia-vue` |

The previous URLs mixed up the repo name and path structure. The Inertia React and Vue starters are subdirectories inside the `adonisjs/starter-kits` monorepo.

## Verification

All 3 new URLs were verified with `curl -L` and return HTTP 200.

A full scan of outbound links in the 2 modified files was also run. Every clickable markdown link resolves to HTTP 200. The only non-200 result is `http://localhost:3333` which appears inside a code block as an example URL, not a clickable link.