### PR TITLE
docs: document signed URL pattern lookup opt-out

### DIFF
--- a/content/guides/basics/url_builder.md
+++ b/content/guides/basics/url_builder.md
@@ -213,6 +213,28 @@ export default class NewsletterMail extends BaseMail {
 
 The `expiresIn` option sets when the signed URL expires. After expiration, the signature is no longer valid. The `prefixUrl` option is required when the URL will be shared externally, such as in emails or external notifications, to ensure the URL includes the full domain. For internal app navigation, relative URLs without the domain are sufficient.
 
+### Creating signed URLs from route patterns
+
+By default, `signedUrlFor` looks up the route by its name and uses the route definition to build the URL. You may disable the lookup when you need to sign a URL from a route pattern that is not registered in the router.
+
+```ts
+import { signedUrlFor } from '@adonisjs/core/services/url_builder'
+
+const url = signedUrlFor(
+  '/files/:key',
+  { key: 'invoice.pdf' },
+  {
+    disableRouteLookup: true,
+    prefixUrl: 'https://example.com',
+    qs: {
+      download: true,
+    },
+  }
+)
+```
+
+When `disableRouteLookup` is enabled, the first argument is parsed as a route pattern and signed directly. Regular `signedUrlFor` calls continue to use route lookup and keep their route-name type safety.
+
 The generated signed URL includes a signature query parameter appended to the URL.
 
 ```text


### PR DESCRIPTION
### 🔗 Linked issue

Code PR: https://github.com/adonisjs/http-server/pull/129  
Discussion: https://github.com/orgs/adonisjs/discussions/5126

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR documents how to generate signed URLs from route patterns without performing a route lookup.

It adds an example for using `signedUrlFor` with `disableRouteLookup: true`, matching the behavior added in adonisjs/http-server#129.

Example:

```ts
signedUrlFor('/files/:key', { key: 'invoice.pdf' }, {
  disableRouteLookup: true,
  prefixUrl: 'https://example.com',
  qs: {
    download: true,
  },
})
```

When `disableRouteLookup` is enabled, the first argument is parsed as a route pattern and signed directly. Regular `signedUrlFor` calls still use route lookup and keep their route-name type safety.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.