### PR TITLE
fix: `code` padding in `h2` titles

### DIFF
--- a/resources/css/markdown.css
+++ b/resources/css/markdown.css
@@ -55,7 +55,8 @@
   font-size: 24px;
   background: transparent;
   color: inherit;
-  padding: 0;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .prose h2,


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/adonisjs/v7-docs/issues/64

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Attempt to fix hard readability when `code` is used within `h2` titles

This is just bug trading tho. It makes `code` section inside `h2` slightly more separated and readable, but at the same time adds whitespace to start of title, when it starts with `code`

It's not really solveable with just CSS, since there's no way to determine, if there is some text at start of `h2` tag or not.
Next and previous sibling selectors ignore text nodes, so in CSS eyes, those to are same:
```html
<h2>This is <code>code</code> in h2</h2>
```
```html
<h2><code>This</code> is code in h2</h2>
```

Maybe there is some cool CSS trick, but I couldn't figure it out

Before: 
<img width="661" height="840" alt="image" src="https://github.com/user-attachments/assets/51f665e2-ced3-41c6-a914-8f9f178ab75b" />


After (notice missaligment in first title near `Request` and whitespaces around `error`):
<img width="1645" height="985" alt="image" src="https://github.com/user-attachments/assets/a17f66b8-d65b-4ed4-9ada-1e3f6776fb1b" />



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
